### PR TITLE
fix max virtual memory areas vm.max_map_count

### DIFF
--- a/images/elasticsearch/Dockerfile
+++ b/images/elasticsearch/Dockerfile
@@ -6,4 +6,5 @@ RUN set -ex \
       && yes | /usr/share/elasticsearch/bin/elasticsearch-plugin install mapper-attachments \
       && find /usr/share/elasticsearch -type d -exec chmod og+rwx {} \; \
       && find /usr/share/elasticsearch -type f -exec chmod +r {} \; \
-      && chmod +x /usr/share/elasticsearch/bin/*
+      && chmod +x /usr/share/elasticsearch/bin/* \
+      && sudo sysctl -w vm.max_map_count=262144

--- a/images/elasticsearch/Dockerfile
+++ b/images/elasticsearch/Dockerfile
@@ -1,10 +1,10 @@
-FROM docker.elastic.co/elasticsearch/elasticsearch:5.5.1
+FROM docker.elastic.co/elasticsearch/elasticsearch:7.12.0
 MAINTAINER Computer Science House
 
 RUN set -ex \
+      && echo vm.max_map_count=262144 >> /etc/sysctl.conf \
       && /usr/share/elasticsearch/bin/elasticsearch-plugin remove x-pack --purge \
       && yes | /usr/share/elasticsearch/bin/elasticsearch-plugin install ingest-attachments \
       && find /usr/share/elasticsearch -type d -exec chmod og+rwx {} \; \
       && find /usr/share/elasticsearch -type f -exec chmod +r {} \; \
-      && chmod +x /usr/share/elasticsearch/bin/* \
-      && sudo sysctl -w vm.max_map_count=262144
+      && chmod +x /usr/share/elasticsearch/bin/*

--- a/images/elasticsearch/Dockerfile
+++ b/images/elasticsearch/Dockerfile
@@ -3,7 +3,7 @@ MAINTAINER Computer Science House
 
 RUN set -ex \
       && /usr/share/elasticsearch/bin/elasticsearch-plugin remove x-pack --purge \
-      && yes | /usr/share/elasticsearch/bin/elasticsearch-plugin install mapper-attachments \
+      && yes | /usr/share/elasticsearch/bin/elasticsearch-plugin install ingest-attachments \
       && find /usr/share/elasticsearch -type d -exec chmod og+rwx {} \; \
       && find /usr/share/elasticsearch -type f -exec chmod +r {} \; \
       && chmod +x /usr/share/elasticsearch/bin/* \


### PR DESCRIPTION
When deploying I get this: `[1]: max virtual memory areas vm.max_map_count [65530] is too low, increase to at least [262144]`

**Full log**
```

[2021-04-13T10:50:50,541][INFO ][o.e.p.PluginsService     ] [WZu8mYM] loaded module [aggs-matrix-stats]


[2021-04-13T10:50:50,541][INFO ][o.e.p.PluginsService     ] [WZu8mYM] loaded module [ingest-common]


[2021-04-13T10:50:50,542][INFO ][o.e.p.PluginsService     ] [WZu8mYM] loaded module [lang-expression]


[2021-04-13T10:50:50,542][INFO ][o.e.p.PluginsService     ] [WZu8mYM] loaded module [lang-groovy]


[2021-04-13T10:50:50,542][INFO ][o.e.p.PluginsService     ] [WZu8mYM] loaded module [lang-mustache]


[2021-04-13T10:50:50,542][INFO ][o.e.p.PluginsService     ] [WZu8mYM] loaded module [lang-painless]


[2021-04-13T10:50:50,542][INFO ][o.e.p.PluginsService     ] [WZu8mYM] loaded module [parent-join]


[2021-04-13T10:50:50,542][INFO ][o.e.p.PluginsService     ] [WZu8mYM] loaded module [percolator]


[2021-04-13T10:50:50,599][INFO ][o.e.p.PluginsService     ] [WZu8mYM] loaded module [reindex]


[2021-04-13T10:50:50,600][INFO ][o.e.p.PluginsService     ] [WZu8mYM] loaded module [transport-netty3]


[2021-04-13T10:50:50,600][INFO ][o.e.p.PluginsService     ] [WZu8mYM] loaded module [transport-netty4]


[2021-04-13T10:50:50,601][INFO ][o.e.p.PluginsService     ] [WZu8mYM] loaded plugin [ingest-geoip]


[2021-04-13T10:50:50,601][INFO ][o.e.p.PluginsService     ] [WZu8mYM] loaded plugin [ingest-user-agent]


[2021-04-13T10:50:50,601][INFO ][o.e.p.PluginsService     ] [WZu8mYM] loaded plugin [mapper-attachments]


[2021-04-13T10:50:51,004][WARN ][d.m.attachment           ] [mapper-attachments] plugin has been deprecated and will be replaced by [ingest-attachment] plugin.


[2021-04-13T10:50:58,503][INFO ][o.e.d.DiscoveryModule    ] [WZu8mYM] using discovery type [zen]


[2021-04-13T10:50:59,934][INFO ][o.e.n.Node               ] initialized


[2021-04-13T10:50:59,935][INFO ][o.e.n.Node               ] [WZu8mYM] starting ...


[2021-04-13T10:51:00,219][INFO ][o.e.t.TransportService   ] [WZu8mYM] publish_address {10.0.1.107:9300}, bound_addresses {0.0.0.0:9300}


[2021-04-13T10:51:00,235][INFO ][o.e.b.BootstrapChecks    ] [WZu8mYM] bound or publishing to a non-loopback or non-link-local address, enforcing bootstrap checks


ERROR: [1] bootstrap checks failed


[1]: max virtual memory areas vm.max_map_count [65530] is too low, increase to at least [262144]


[2021-04-13T10:51:00,252][INFO ][o.e.n.Node               ] [WZu8mYM] stopping ...


[2021-04-13T10:51:00,329][INFO ][o.e.n.Node               ] [WZu8mYM] stopped


[2021-04-13T10:51:00,330][INFO ][o.e.n.Node               ] [WZu8mYM] closing ...


[2021-04-13T10:51:00,418][INFO ][o.e.n.Node               ] [WZu8mYM] closed
```